### PR TITLE
certus: Set screen density to physical PPI

### DIFF
--- a/product_prop.mk
+++ b/product_prop.mk
@@ -42,6 +42,10 @@ PRODUCT_PRODUCT_PROPERTIES  += \
     ro.mtk_perf_fast_start_win=1 \
     ro.mtk_perf_response_time=1
 
+# Screen Density
+PRODUCT_PRODUCT_PROPERTIES  += \
+    ro.sf.lcd_density=295
+
 # Surfaceflinger
 PRODUCT_PRODUCT_PROPERTIES  += \
    ro.surface_flinger.force_hwc_copy_for_virtual_displays=true \


### PR DESCRIPTION
This stops the display looking to small by default. Stock DPI was tried, however items then looked too big. Physical PPI looks best